### PR TITLE
Removed repeated entries and small typos

### DIFF
--- a/Resources.md
+++ b/Resources.md
@@ -4,9 +4,9 @@
 
 A collection of resources that provide information, guidance, and tools related to the field of Artificial Intelligence.
 
-### Online courses and tutorials: 
+### Online courses and tutorials:
 "Machine Learning" by Andrew Ng - This course is one of the most popular and highly recommended online courses on machine learning, offered by Coursera. It covers a wide range of topics, including supervised learning, unsupervised learning, and neural networks.<br>
-Link: https://www.coursera.org/learn/machine-learning 
+Link: https://www.coursera.org/learn/machine-learning
 
 "Deep Learning" by Andrew Ng - This is another highly regarded course offered by Coursera, covering the principles and applications of deep learning. It includes topics such as convolutional neural networks, recurrent neural networks, and sequence models.<br>
 Link: https://www.coursera.org/specializations/deep-learning
@@ -35,7 +35,7 @@ Link: https://www.coursera.org/learn/ai-for-everyone
 "Deep Reinforcement Learning" - This is a free course offered by the University of Alberta on Coursera that covers the basics of reinforcement learning, including Q-learning, policy gradients, and actor-critic methods. It includes practical examples and coding assignments.<br>
 Link: https://www.coursera.org/specializations/deep-reinforcement-learning
 
-### Books and publications: 
+### Books and publications:
 * [Deep Learning by Ian Goodfellow, Yoshua Bengio, and Aaron Courville (2016) ](https://www.deeplearningbook.org/) This book is a comprehensive introduction to deep learning, covering both theoretical foundations and practical applications. It is widely regarded as one of the most authoritative and accessible texts on the subject.
 * [Artificial Intelligence: A Modern Approach by Stuart Russell and Peter Norvig (2010)](https://www.amazon.com/Artificial-Intelligence-Modern-Approach-3rd/dp/0136042597)This is a classic textbook on AI that covers a wide range of topics, from search and optimization to machine learning and robotics. It is used in many undergraduate and graduate courses on AI.
 * [Human Compatible: Artificial Intelligence and the Problem of Control by Stuart Russell (2019)](https://www.amazon.com/Human-Compatible-Artificial-Intelligence-Control/dp/0525558616) This book explores the societal implications of AI and argues that we need to ensure that AI is aligned with human values and goals. It offers a thought-provoking perspective on the ethical and governance challenges posed by AI.
@@ -47,62 +47,62 @@ Link: https://www.coursera.org/specializations/deep-reinforcement-learning
 * [The Master Algorithm: How the Quest for the Ultimate Learning Machine Will Remake Our World by Pedro Domingos (2015)](https://www.amazon.com/Master-Algorithm-Ultimate-Learning-Machine/dp/0465094279)This book explores the potential of machine learning to transform various industries and aspects of our lives. It presents a vision of a "master algorithm" that can learn from any kind of data.
 * [Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow by Aurélien Géron (2019) ](https://www.oreilly.com/library/view/hands-on-machine-learning/9781492032632/)This book offers a practical guide to building and deploying machine learning models using popular Python libraries such as Scikit-Learn, Keras, and TensorFlow. It covers a wide range of topics, from data preprocessing to deep learning.
 
-### Research papers and articles: 
-|  Name  |  Description  |  URL  | Year 
-| :-----:| :------------:| :----:| :----:   
+### Research papers and articles:
+|  Name  |  Description  |  URL  | Year
+| :-----:| :------------:| :----:| :----:
 | Attention Is All You Need |  Introduction to the Transformer model. |  [URL](https://arxiv.org/abs/1706.03762)  | 2017
 | ImageNet Classification with Deep Convolutional Neural Networks | Introduction to the concept of deep learning and convolutional neural networks| [URL](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf) | 2012
 | Generative Adversarial Networks | Introduction to the concept of generative adversarial networks  | [URL](https://arxiv.org/abs/1406.2661)  | 2014
 | Playing Atari with Deep Reinforcement Learning | Demonstrates that deep reinforcement learning can be used to learn to play Atari games                                    | [URL](https://www.cs.toronto.edu/~vmnih/docs/dqn.pdf) | 2013
 |  BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding | Introduction to the BERT model | [URL](https://arxiv.org/abs/1810.04805)| 2018
 |  Deep Residual Learning for Image Recognition | Introduction to ResNet | [URL](https://arxiv.org/abs/1512.03385)  | 2016
-| AlphaGo: Mastering the game of Go with deep neural networks and tree search  | Introduction to the AlphaGo system | [UURL](https://www.nature.com/articles/nature16961) | 2016
-| Unsupervised Representation Learning with Deep Convolutional Generative Adversarial Networks| Introduction to the attention mechanism for neural machine translation                                   |  [UURL](https://arxiv.org/abs/1511.06434)   | 2016
-| DeepFace: Closing the Gap to Human-Level Performance in Face Verification | Introduction to the DeepFace model|  [UURL](https://www.cs.toronto.edu/~ranzato/publications/taigman_cvpr14.pdf)   | 2014
-|  Neural Ordinary Differential Equations | Introduction to the concept of neural ordinary differential equations |  [UURL](https://arxiv.org/abs/1806.07366)   | 2018
-|  The Lottery Ticket Hypothesis: Finding Sparse, Trainable Neural Networks |  Introduction to the idea that large neural networks contain smaller "winning tickets"  |  [UURL](https://arxiv.org/abs/1803.03635)   |2019
+| AlphaGo: Mastering the game of Go with deep neural networks and tree search  | Introduction to the AlphaGo system | [URL](https://www.nature.com/articles/nature16961) | 2016
+| Unsupervised Representation Learning with Deep Convolutional Generative Adversarial Networks| Introduction to the attention mechanism for neural machine translation                                   |  [URL](https://arxiv.org/abs/1511.06434)   | 2016
+| DeepFace: Closing the Gap to Human-Level Performance in Face Verification | Introduction to the DeepFace model|  [URL](https://www.cs.toronto.edu/~ranzato/publications/taigman_cvpr14.pdf)   | 2014
+|  Neural Ordinary Differential Equations | Introduction to the concept of neural ordinary differential equations |  [URL](https://arxiv.org/abs/1806.07366)   | 2018
+|  The Lottery Ticket Hypothesis: Finding Sparse, Trainable Neural Networks |  Introduction to the idea that large neural networks contain smaller "winning tickets"  |  [URL](https://arxiv.org/abs/1803.03635)   |2019
 
-### AI communities and forums: 
+### AI communities and forums:
 * [Kaggle:](https://www.kaggle.com/)
 > A community of data scientists and machine learning enthusiasts
-* [Hugging Face:](https://huggingface.co/) 
+* [Hugging Face:](https://huggingface.co/)
 > The AI community building the future
-* [Stack Overflow:](https://stackoverflow.com/) 
+* [Stack Overflow:](https://stackoverflow.com/)
 > A Q&A forum for developers to ask and answer technical questions, including those related to AI.
-* [Reddit Machine Learning:](https://www.reddit.com/r/MachineLearning/) 
+* [Reddit Machine Learning:](https://www.reddit.com/r/MachineLearning/)
 > A subreddit dedicated to discussion and news related to machine learning and artificial intelligence.
-* [TensorFlow:](https://www.tensorflow.org/community) 
+* [TensorFlow:](https://www.tensorflow.org/community)
 > A popular machine learning library from Google, with an active community of users and contributors.
-* [PyTorch:](https://discuss.pytorch.org/) 
+* [PyTorch:](https://discuss.pytorch.org/)
 > Another popular machine learning library with an active community of users and contributors.
-* [OpenAI:](https://community.openai.com/) 
+* [OpenAI:](https://community.openai.com/)
 > A research organization dedicated to advancing AI in a safe and beneficial way
-* [AI Stack Exchange:](https://ai.stackexchange.com/) 
+* [AI Stack Exchange:](https://ai.stackexchange.com/)
 > A Q&A forum for AI-related questions, similar to Stack Overflow.
-* [Data Science Central:](https://www.datasciencecentral.com/) 
+* [Data Science Central:](https://www.datasciencecentral.com/)
 > A community of data scientists and machine learning practitioners sharing knowledge and resources.
-* [Learn prompting:](https://learnprompting.org/) 
+* [Learn prompting:](https://learnprompting.org/)
 > A community of AI enthusiasts dedicated to exploring and advancing the field of GPT-based natural language processing
-* [DataCamp:](https://www.datacamp.com/) 
+* [DataCamp:](https://www.datacamp.com/)
 > Leading online learning platform
-* [Code Academy:](https://www.codecademy.com/) 
+* [Code Academy:](https://www.codecademy.com/)
 > Online community of coders, developers, and tech enthusiasts
-* [FreeCodeCamp:](https://www.freecodecamp.org/) 
+* [FreeCodeCamp:](https://www.freecodecamp.org/)
 > A community dedicated to teaching people to code for free
-* [Zero to Mastery:](https://zerotomastery.io/) 
+* [Zero to Mastery:](https://zerotomastery.io/)
 > Anonline community offering a range of courses
 * [DeepLearning.AI:](https://www.deeplearning.ai/blog/category/community/)
 > A hub for AI enthusiasts to learn, connect, and grow
-* [Google AI:](https://ai.google/) 
+* [Google AI:](https://ai.google/)
 > A community of researchers, engineers, and developers working on Google’s AI initiatives.
-* [NVIDIA Developer Zone:](https://developer.nvidia.com/) 
+* [NVIDIA Developer Zone:](https://developer.nvidia.com/)
 > A community of developers using NVIDIA GPUs for AI and machine learning projects.
-* [Machine Learning Mastery:](https://machinelearningmastery.com/start-here/) 
+* [Machine Learning Mastery:](https://machinelearningmastery.com/start-here/)
 > A community of machine learning practitioners and learners, with a focus on practical tutorials and projects.
-* [MidJourney:](https://www.midjourney.com/home/?callbackUrl=%2Fapp%2F) 
+* [MidJourney:](https://www.midjourney.com/home/?callbackUrl=%2Fapp%2F)
 > Stay updated on the latest trends and techniques in AI, machine learning, and data science
 
-### AI conferences and workshops: 
+### AI conferences and workshops:
 >Conference on Neural Information Processing Systems (NeurIPS) - This is one of the largest and most prestigious AI conferences in the world, covering a wide range of topics in machine learning, deep learning, and artificial intelligence.
 Link: https://neurips.cc/
 
@@ -117,20 +117,9 @@ Link: https://aaai.org/
 
 >Conference on Computer Vision and Pattern Recognition (CVPR) - This is a conference focused on computer vision and image processing, covering topics such as object recognition, image segmentation, and deep learning for visual recognition.
 Link: http://cvpr2022.thecvf.com/
-Conference on Neural Information Processing Systems (NeurIPS) - This is one of the largest and most prestigious AI conferences in the world, covering a wide range of topics in machine learning, deep learning, and artificial intelligence.
-Link: https://neurips.cc/
 
 >International Conference on Machine Learning (ICML) - This is another major AI conference that covers topics in machine learning and deep learning, as well as related fields such as computer vision, natural language processing, and robotics.
 Link: https://icml.cc/
-
->International Conference on Learning Representations (ICLR) - This is a conference focused on representation learning, a key area of research in machine learning and deep learning. It covers topics such as unsupervised learning, generative models, and reinforcement learning.
-Link: https://iclr.cc/
-
->AAAI Conference on Artificial Intelligence (AAAI) - This is a conference that covers a wide range of topics in artificial intelligence, including natural language processing, computer vision, robotics, and decision making.
-Link: https://aaai.org/
-
->Conference on Computer Vision and Pattern Recognition (CVPR) - This is a conference focused on computer vision and image processing, covering topics such as object recognition, image segmentation, and deep learning for visual recognition.
-Link: http://cvpr2022.thecvf.com/
 
 >International Joint Conference on Artificial Intelligence (IJCAI) - This is one of the oldest and most prestigious AI conferences in the world, covering topics such as knowledge representation, reasoning, planning, and natural language processing.
 Link: https://www.ijcai.org/
@@ -138,7 +127,7 @@ Link: https://www.ijcai.org/
 >Association for Computational Linguistics (ACL) - This is a conference focused on natural language processing and computational linguistics, covering topics such as machine translation, text classification, sentiment analysis, and dialogue systems.
 Link: https://aclweb.org/aclwiki/Conference_portal
 
-### Open-source software and tools: 
+### Open-source software and tools:
 >[TensorFlow](https://www.tensorflow.org/) - This is an open source machine learning library developed by Google, which allows developers to create and deploy machine learning models at scale.
 
 


### PR DESCRIPTION
To review this PR, you need to expand all the rows so you see that the conference names I removed are still included. Meaning they were twice. For example I removed ICLR, but you still have the first one on line 112. 

Some links had UUL instead of UL (lines 59 - 63)
My VSC removed extra white spaces. 

@natnew 