### PR TITLE
Add TinyTools Prompt Injection Tester to Safety & Guardrails section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The field has evolved from crafting individual prompts to architecting complete 
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) — NVIDIA's toolkit for LLM safety
 - [Rebuff](https://github.com/protectai/rebuff) — Prompt injection detection and prevention
 - [Lakera Guard](https://www.lakera.ai/) — Real-time protection against prompt attacks
+- [TinyTools Prompt Injection Tester](https://tinytools-smoky.vercel.app/prompt-injection-tester/) — Free browser-based tester that runs prompts against a library of common injection attacks (instruction overrides, role hijacks, data exfiltration). Client-side, no signup.
 
 ---
 ## Announcements :eyes:


### PR DESCRIPTION
Hi! Adding **TinyTools Prompt Injection Tester** to the **Safety & Guardrails** section.

**What it is:** A free, browser-based tool that tests prompts against a library of common injection attack patterns — instruction overrides, role-hijacks, data-exfiltration attempts, jailbreak templates, etc. Useful for engineers stress-testing their LLM apps before shipping.

**Why it fits Safety & Guardrails:** The current entries (Guardrails AI, NeMo Guardrails, Rebuff, Lakera Guard) cover *runtime* defense; this fills the *pre-deployment testing* gap — letting devs verify their prompts hold up against known attacks before the guardrails ever need to fire.

**Details:**
- 100% client-side (no signup, no data leaves the browser)
- Free, no rate limits
- Open source — part of [TinyTools](https://tinytools-smoky.vercel.app/), a collection of single-purpose web utilities

Happy to adjust placement or wording. Thanks for maintaining this list!