### PR TITLE
Add Future AGI ai-evaluation and agent-opt to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The field has evolved from crafting individual prompts to architecting complete 
 - [TruLens](https://www.trulens.org/) — Feedback and evaluation for LLM applications
 - [Weave](https://wandb.ai/site/weave) — Trace-based debugging and scoring from Weights & Biases
 - [Maxim AI](https://www.getmaxim.ai/) — Systematic evaluation and benchmarking platform
-- [ai-evaluation](https://github.com/future-agi/ai-evaluation) — Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge augmentation, and guardrail scanners (jailbreak, PII, prompt-injection); AutoEval pipelines with CI/CD support
-- [agent-opt](https://github.com/future-agi/agent-opt) — Open-source library for evaluation-driven prompt and agent-workflow optimization with six algorithms (Random, Bayesian, ProTeGi, Meta-Prompt, PromptWizard, GEPA)
+- [ai-evaluation](https://github.com/future-agi/ai-evaluation) — Open-source LLM evaluation SDK with local metrics, LLM-as-judge support, guardrail scanners, and AutoEval pipelines
+- [agent-opt](https://github.com/future-agi/agent-opt) — Evaluation-driven prompt and agent workflow optimisation using search, meta-prompting, PromptWizard, and GEPA
 
 ### Safety & Guardrails
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The field has evolved from crafting individual prompts to architecting complete 
 - [TruLens](https://www.trulens.org/) — Feedback and evaluation for LLM applications
 - [Weave](https://wandb.ai/site/weave) — Trace-based debugging and scoring from Weights & Biases
 - [Maxim AI](https://www.getmaxim.ai/) — Systematic evaluation and benchmarking platform
+- [ai-evaluation](https://github.com/future-agi/ai-evaluation) — Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge augmentation, and guardrail scanners (jailbreak, PII, prompt-injection); AutoEval pipelines with CI/CD support
+- [agent-opt](https://github.com/future-agi/agent-opt) — Open-source library for evaluation-driven prompt and agent-workflow optimization with six algorithms (Random, Bayesian, ProTeGi, Meta-Prompt, PromptWizard, GEPA)
 
 ### Safety & Guardrails
 


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed.

- traceAI: https://github.com/future-agi/traceAI
- ai-evaluation: https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- future-agi (umbrella): https://github.com/future-agi/future-agi
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section. Single-purpose diff: only README updates.