### PR TITLE
Add Prompt Engineering Techniques to Guides and Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The field has evolved from crafting individual prompts to architecting complete 
 ##### [AI Agents Guide](https://natnew.github.io/Awesome-Prompt-Engineering/Agents.html)
 ##### [Prompt Engineering Guide by Learn Prompting](https://learnprompting.org/docs/introduction)
 ##### [DAIR.AI Prompt Engineering Guide](https://www.promptingguide.ai/)
+##### [Prompt Engineering Techniques (NirDiamant)](https://github.com/NirDiamant/Prompt_Engineering)
 ##### [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering)
 ##### [Anthropic Prompt Engineering Guide](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)
 


### PR DESCRIPTION
This adds the **Prompt Engineering Techniques** repo to the *Guides and Learning Resources* section.

- Link: https://github.com/NirDiamant/Prompt_Engineering
- 22 prompt engineering techniques, each with a runnable, hands-on Jupyter Notebook tutorial, covering everything from fundamentals to advanced LLM strategies (7k+ stars, actively maintained).

It sits naturally alongside the other learning guides in this section and follows the existing entry format. Disclosure: I am the author of the repository.