### PR TITLE
Add "The context window is a cache, not a memory" to Recommended Reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The field has evolved from crafting individual prompts to architecting complete 
 - [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — Anthropic's engineering best practices
 - [Prompt Engineering Best Practices](https://claude.com/blog/best-practices-for-prompt-engineering) — Claude's official guide
 - [OpenAI Prompt Engineering Guide](https://help.openai.com/en/articles/6654000-best-practices-for-prompt-engineering-with-the-openai-api) — OpenAI's official documentation
+- [The context window is a cache, not a memory](https://loopandretry.github.io/posts/context-window-is-a-cache/?ref=awesome-prompt-eng) — Why treating an agent's context window as durable memory quietly breaks long runs, and how to design context that survives eviction.
 
 ---
 ## Modern Tools & Frameworks


### PR DESCRIPTION
Adds one practitioner essay to Recommended Reading (Context Engineering).

Link: https://loopandretry.github.io/posts/context-window-is-a-cache/

Why it fits: a context-engineering field note on why an agent context window behaves like an evictable cache rather than durable memory — same lane as the existing DAIR.AI and Anthropic context-engineering guides.

Disclosure: I write this blog; submitting because it is on-topic, not promotional.