### PR TITLE
Add StructEval to Evaluation & Testing

### DIFF
--- a/Resources.md
+++ b/Resources.md
@@ -155,6 +155,7 @@ A practitioner's guide to learning resources for building, deploying, evaluating
 | **"LLM-as-Judge"** | Using LLMs to evaluate LLM outputs | [arxiv.org](https://arxiv.org/abs/2306.05685) |
 | **"WFGY 16 Problem Map"** | Troubleshooting guide for RAG and LLM pipelines | [github.com](https://github.com/onestardao/WFGY/tree/main/ProblemMap/README.md) |
 | **Anthropic's Evaluation Documentation** | How Anthropic thinks about evals | [docs.anthropic.com](https://docs.anthropic.com/en/docs/build-with-claude/develop-tests) |
+| **"StructEval: Benchmarking LLMs' Capabilities to Generate Structural Outputs"** | TMLR 2025 benchmark for structural-output generation and conversion across text and visual formats | [arxiv.org](https://arxiv.org/abs/2505.20139) |
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds the TMLR 2025 StructEval paper to `Resources.md` under Evaluation & Testing → Key Reading. StructEval benchmarks structural-output generation and conversion across text and visual formats.

## Type of change

- [x] New resource / tool / link
- [ ] Fix (broken link, typo, wrong description or category)
- [ ] Content update to an existing page
- [ ] Other (please describe)

## New entry details

- **Name and link:** [StructEval: Benchmarking LLMs' Capabilities to Generate Structural Outputs](https://arxiv.org/abs/2505.20139)
- **Category / page it belongs in:** `Resources.md` → Evaluation & Testing → Key Reading
- **Why it belongs here:** It provides a published benchmark for evaluating output-format adherence across 2,035 examples, 18 text and visual formats, and generation and conversion tasks.

## Contributor checklist

- [x] Searched the repo for duplicates (URL and name)
- [x] Link is canonical and uses HTTPS
- [x] Description is neutral and factual
- [x] Added at the bottom of the section
- [x] Only one logical change
- [x] PR is ready for review
- [x] Spelling and Markdown lint checked

I am a StructEval maintainer and am submitting this entry transparently for maintainer review.

This contribution was prepared with assistance from OpenAI Codex.