### PR TITLE
chore: remove Tidio chat widget, add Playground link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ The field has evolved from crafting individual prompts to architecting complete 
   </tr>
 </table>
 
+<table>
+  <tr>
+    <td width="100%">
+      Try the <a href="https://prompt-engineering-strapp.streamlit.app/about">Prompt Engineering Playground.</a> Interactive app for exploring prompt engineering techniques across models including GPT-4o and GPT-4 Turbo.
+    </td>
+  </tr>
+</table>
+
 ---
 ## More Awesome Lists
 

--- a/_includes/tidio.html
+++ b/_includes/tidio.html
@@ -1,1 +1,0 @@
-<script src="//code.tidio.co/9inzrydcnmlyhvekrdaky7vtsohlkah0.js" async></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,8 +78,6 @@
     })();
   </script>
 
-  <!-- Include the Tidio script -->
-  {% include tidio.html %}
 </body>
 
 </html>


### PR DESCRIPTION
Follow-up to #78. These two commits were pushed after that PR was merged, so they never landed.

- Removes the Tidio chat widget: deletes `_includes/tidio.html` and its `{% include %}` in the layout. The widget is still live on the site until this merges.
- Adds the Prompt Engineering Playground to Additional Resources.


