### PR TITLE
Add PerspectiveGap to Evaluation & Testing

### DIFF
--- a/Resources.md
+++ b/Resources.md
@@ -155,6 +155,7 @@ A practitioner's guide to learning resources for building, deploying, evaluating
 | **"LLM-as-Judge"** | Using LLMs to evaluate LLM outputs | [arxiv.org](https://arxiv.org/abs/2306.05685) |
 | **"WFGY 16 Problem Map"** | Troubleshooting guide for RAG and LLM pipelines | [github.com](https://github.com/onestardao/WFGY/tree/main/ProblemMap/README.md) |
 | **Anthropic's Evaluation Documentation** | How Anthropic thinks about evals | [docs.anthropic.com](https://docs.anthropic.com/en/docs/build-with-claude/develop-tests) |
+| **"PerspectiveGap: A Benchmark for Multi-Agent Orchestration Prompting"** | Benchmarks role-fragment assignment and free-form prompt writing across 110 multi-agent orchestration scenarios and 10 topologies | [arxiv.org](https://arxiv.org/abs/2606.08878) |
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds PerspectiveGap to `Resources.md` under Evaluation & Testing → Key Reading. This follows the suggestion in #75 to submit the benchmark separately with a neutral description of its evaluation design.

## Type of change

- [x] New resource / tool / link
- [ ] Fix (broken link, typo, wrong description or category)
- [ ] Content update to an existing page
- [ ] Other (please describe)

## New entry details

- **Name and link:** [PerspectiveGap: A Benchmark for Multi-Agent Orchestration Prompting](https://arxiv.org/abs/2606.08878)
- **Category / page it belongs in:** `Resources.md` → Evaluation & Testing → Key Reading
- **Why it belongs here:** The benchmark tests role-fragment assignment and free-form prompt writing across 110 multi-agent orchestration scenarios organized into 10 topologies.

## Contributor checklist

- [x] Searched the repo for duplicates (URL and name)
- [x] Link is canonical and uses HTTPS
- [x] Description is neutral and factual
- [x] Added at the bottom of the section
- [x] Only one logical change
- [x] PR is ready for review
- [x] Spelling and Markdown lint checked
